### PR TITLE
Add failing test for 'toString' on media queries

### DIFF
--- a/test/StyleSheet.js
+++ b/test/StyleSheet.js
@@ -107,6 +107,15 @@ test('toString named', function () {
     ss.detach()
 })
 
+test('toString named with media query', function () {
+    jss.Rule.uid = 0
+    var ss = new jss.StyleSheet({a: {color: 'red'}, '@media (min-width: 1024px)': {a: {color: 'blue'}}})
+    ss.attach()
+    equal(ss.toString(), '.jss-0 {\n  color: red;\n}\n@media (min-width: 1024px) {\n  .jss-0 {\n    color: blue;\n  }\n}')
+    equal(ss.element.innerHTML, '\n.jss-0 {\n  color: red;\n}\n@media (min-width: 1024px) {\n  .jss-0 {\n    color: blue;\n  }\n}\n')
+    ss.detach()
+})
+
 test('link', function () {
     var ss = new jss.StyleSheet({a: {float: 'left'}}, {link: true})
     ss.attach()


### PR DESCRIPTION
I seem to have found a bug when calling `toString` on style sheets with media queries.

I'm not sure yet how to fix this, but I figured I'd open a discussion by providing a failing test.

The current failing test case shows how this:

```js
{a: {color: 'red'}, '@media (min-width: 1024px)': {a: {color: 'blue'}}}
```

is erroneously compiled into this:

```css
.jss-0 {
  color: red;
}
.jss-1 {
  a: [object Object];
}
```