### PR TITLE
Return added rules from styleSheet.addRules()

### DIFF
--- a/lib/StyleSheet.js
+++ b/lib/StyleSheet.js
@@ -154,15 +154,17 @@ StyleSheet.prototype.addRule = function (key, style) {
  * Create rules, will render also after stylesheet was rendered the first time.
  *
  * @param {Object} rules key:style hash.
- * @return {StyleSheet} this
+ * @return {Array} array of added rules
  * @api public
  */
 StyleSheet.prototype.addRules = function (rules) {
+    var added = []
+    
     for (var key in rules) {
-        this.addRule(key, rules[key])
+        added.push.apply(added, this.addRule(key, rules[key]))
     }
 
-    return this
+    return added
 }
 
 /**


### PR DESCRIPTION
Without this, there is no way to get the `classNames` that are related ONLY to the rules that have been currently added (with `addRules()`). This is different from `styleSheet.rules` , which stores ALL current rules.

A use case is when we need the `classNames` of some added rules, while rendering on the server. Maybe there is a need to add rules of all components in a tree, to the same global StyleSheet instance. That instance will be created on each request. We need `classNames` of each component, before calling `styleSheet.toString()` at the final step, when all rules have been added and the complete tree has been rendered. In that case we have to get the `classNames` from the returned values of `addRule()/addRules()`.