### PR TITLE
Make the `use` method variadic.

### DIFF
--- a/src/Jss.js
+++ b/src/Jss.js
@@ -60,11 +60,11 @@ export default class Jss {
   /**
    * Register plugin. Passed function will be invoked with a rule instance.
    *
-   * @param {Function} fn
+   * @param {Function} plugins
    * @api public
    */
-  use(fn) {
-    this.plugins.use(fn)
+  use(...plugins) {
+    plugins.forEach(plugin => this.plugins.use(plugin))
     return this
   }
 }

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -195,6 +195,16 @@ test('add plugin', () => {
   jss.plugins.registry = []
 })
 
+test('add multiple plugins', () => {
+  const plugin = () => {}
+  const plugin2 = () => {}
+  jss.use(plugin, plugin2)
+  equal(jss.plugins.registry.length, 2)
+  strictEqual(jss.plugins.registry[0], plugin)
+  strictEqual(jss.plugins.registry[1], plugin2)
+  jss.plugins.registry = []
+})
+
 test('run plugins', () => {
   let executed = false
   function plugin() {
@@ -205,6 +215,7 @@ test('run plugins', () => {
   ok(executed)
   jss.plugins.registry = []
 })
+
 
 test('run plugins on inner rules of an conditional rule', () => {
   let executed = 0


### PR DESCRIPTION
This allows you to use the `use` method like so:
```js
jss.use(extend(), nested(), defaultUnit());
```