### PR TITLE
Fixes typos in docs

### DIFF
--- a/docs/benefits.md
+++ b/docs/benefits.md
@@ -8,23 +8,23 @@
 
 1. True rules isolation.
 
-  Scoped selectors are not enough. CSS has properties which are inherited automatically from the parent element, if not explicitely defined. Thanks to [jss-isolate](https://github.com/jsstyles/jss-isolate) plugin, JSS rules will not inherit properties.
+  Scoped selectors are not enough. CSS has properties which are inherited automatically from the parent element, if not explicitly defined. Thanks to [jss-isolate](https://github.com/jsstyles/jss-isolate) plugin, JSS rules will not inherit properties.
 
 1. Avoids specificity conflicts.
 1. Source order independence.
 1. Slow selectors.
 
-  Because JSS rules are collision free, there is no need to write deeply netsted selectors. This leads to stable [performance](./performance.md) at scale.
+  Because JSS rules are collision free, there is no need to write deeply nested selectors. This leads to stable [performance](./performance.md) at scale.
 
 1. Code reuse, expressiveness.
 
   CSS is limited to applying multiple selectors to the same node in its code reuse capabilities.
-JSS allows you to compose rules from multiple sources. You can reuse existing rules, you can use functions to generate rules and to calculate values. This way we can avoid repeatitions in a very explicit way.
+JSS allows you to compose rules from multiple sources. You can reuse existing rules, you can use functions to generate rules and to calculate values. This way we can avoid repetitions in a very explicit way.
 
 1. Refactoring.
 
   Thanks to javascript modules and explicit code reuse, we can quickly locate dependencies during refactoring.
-  
+
 1. Dead code elimination.
 
   If you put your styles into a component where they are used and use closure compiler.
@@ -48,8 +48,8 @@ JSS allows you to compose rules from multiple sources. You can reuse existing ru
 ### Compared to server-side preprocessing languages (stylus/less/sass/css-modules and co.)
 
 1. Aforementioned benefits.
-1. There is no build step, as a result - no dependency to build tools at all. 
-1. Just one language, standartized by w3c.
+1. There is no build step, as a result - no dependency to build tools at all.
+1. Just one language, standardized by w3c.
 
   There is no need to learn new preprocessing languages. They all come with a burden of a new syntax for variables, functions, mixins, extends and others. At the same time there is nothing they can do JavaScript can't.
 

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -110,7 +110,7 @@ let sheet = jss.createStyleSheet({
 ```javascript
 jss.sheets.registry // an array with all style sheets
 
-jss.sheets.toString() // Returns CSS of all style sheets together. Usefull for server-side rendering.
+jss.sheets.toString() // Returns CSS of all style sheets together. Useful for server-side rendering.
 ```
 
 ### Attach style sheet.
@@ -123,7 +123,7 @@ Insert style sheet into the render tree. You need to call it in order to make yo
 
 `sheet.detach()`
 
-Detaching unsused style sheets will speedup every DOM node insertion and manipulation as the browser will have to do less lookups for css rules potentially to be applied to the element.
+Detaching unused style sheets will speedup every DOM node insertion and manipulation as the browser will have to do less lookups for css rules potentially to be applied to the element.
 
 ### Add a rule to an existing style sheet.
 

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -125,7 +125,7 @@ export default {
 ```css
 @font-face {
   font-family: 'MyWebFont';
-  src: url('webfont.eot'); 
+  src: url('webfont.eot');
   src: url('webfont.eot?#iefix') format('embedded-opentype');
   src: url('webfont.woff2') format('woff2');
 }       
@@ -156,7 +156,7 @@ export default {
 ```
 ### Writing global selectors
 
-When using option "named" `jss.createStyleSheet(styles, {named: false})` you can use keys as selectors instead of names. Be carefull, now you will be writing a regular Style Sheet with global selectors.
+When using option "named" `jss.createStyleSheet(styles, {named: false})` you can use keys as selectors instead of names. Be careful, now you will be writing a regular Style Sheet with global selectors.
 
 ```javascript
 export default {


### PR DESCRIPTION
Minor tweaks to docs.

benefits.md
+ explicitely => explicitly
+ netsted => nested
+ repeatitions => repetitions
+ standartized => standardized

js-api.md
+ Usefull => Useful
+ unsused => unused

json-api.md
+ carefull => careful

Feel free to correct me if I made mistake to words :)