### PR TITLE
Media queries and other conditional selectors before the rules they overwrite

### DIFF
--- a/src/StyleSheet.js
+++ b/src/StyleSheet.js
@@ -171,7 +171,8 @@ export default class StyleSheet {
       ...options,
       sheet: this,
       jss: this.options.jss,
-      Renderer: this.options.Renderer
+      Renderer: this.options.Renderer,
+      className: this.classes[name]
     }
     // Scope options overwrite instance options.
     if (options.named == null) options.named = this.options.named

--- a/tests/integration/sheet.js
+++ b/tests/integration/sheet.js
@@ -1,5 +1,5 @@
 import expect from 'expect.js'
-import jss, {Rule} from 'jss'
+import jss, { create as createJss, Rule} from 'jss'
 import {reset} from '../utils'
 
 afterEach(reset)
@@ -39,6 +39,22 @@ describe('Integration: sheet', () => {
         }
       })
       expect(sheet.classes.a).to.be('a-id')
+    })
+
+    it('should generate the same class name for the same selectors within single stylesheet', () => {
+      // create new Jss instance with unmodified "jss.generateClassName()"
+      const jss = createJss()
+
+      const sheet = jss.createStyleSheet({
+        '@media print': {
+          a: {float: 'left'}
+        },
+        a: {color: 'yellow'}
+      })
+      const aInRoot = sheet.getRule('a')
+      const aInMedia = sheet.getRule('@media print').rules.a
+
+      expect(aInRoot.className).to.be.eql(aInMedia.className)
     })
   })
 


### PR DESCRIPTION
Implements #180

I wanted to add a test for this, but looks like with the current test setup it is hard to verify the scenario, because `jss.generateClassName()` always generates class names with the same suffix: https://github.com/jsstyles/jss/blob/master/tests/utils.js#L44 . Please let me know if you'd like to still have a test for it and advise how to overcome the aforementioned issue.